### PR TITLE
feat: Add run.sh for cross-platform consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For a consistent and easy-to-manage setup on any operating system (including Win
 
 ### Running the Application with Docker
 
-We have provided a simple script for Windows users to manage the application.
+We have provided simple scripts to manage the application on all major operating systems.
 
 **On Windows:**
 
@@ -141,7 +141,7 @@ Open a PowerShell terminal and run:
 
 Open a terminal and run:
 ```bash
-docker-compose up -d --build
+./run.sh up
 ```
 
 This will build the Docker images for the frontend and backend, start the containers in the background, and persist your game data in the `game-backend-new/data` directory.
@@ -161,5 +161,5 @@ To stop the application and shut down the containers, run:
 
 **On macOS and Linux:**
 ```bash
-docker-compose down
+./run.sh down
 ```

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+    echo "Docker is not running. Please start Docker and try again." >&2
+    exit 1
+fi
+
+COMMAND="$1"
+
+case "$COMMAND" in
+    up)
+        echo "Starting the application with Docker Compose..."
+        docker-compose up -d --build
+        echo "Application is running. Frontend: http://localhost:3000 | Backend: http://localhost:8000"
+        ;;
+    down)
+        echo "Stopping the application..."
+        docker-compose down
+        echo "Application stopped."
+        ;;
+    *)
+        echo "Usage: ./run.sh [up|down]"
+        echo "  up   : Builds and starts the application in detached mode."
+        echo "  down : Stops and removes the application containers."
+        ;;
+esac


### PR DESCRIPTION
The project included a `run-windows.ps1` script but relied on direct `docker-compose` commands for macOS and Linux.

To improve the user experience, this change introduces a `run.sh` script for macOS and Linux that mirrors the functionality of the Windows script.

The `README.md` has been updated to refer to the new script, providing unified instructions for all platforms.