### PR TITLE
Fix: Correct deployment URLs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Terroir & Time: A Natural Winemaking Saga
 
-[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/kennethkcox/winer-0.1)
-[![Deploy to DigitalOcean](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/kennethkcox/winer-0.1)
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/kennethkcox/winer)
+[![Deploy to DigitalOcean](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/kennethkcox/winer)
 
 Welcome to "Terroir & Time," a simulation game where you embark on the journey of a natural winemaker. From purchasing your first vineyard to bottling your unique creations, every decision you make will shape your wine and your legacy.
 


### PR DESCRIPTION
The 'Deploy to Heroku' and 'Deploy to DigitalOcean' buttons in the README.md were pointing to an incorrect repository URL (winer-0.1). This was causing an error during deployment.

This commit updates the URLs to point to the correct repository, resolving the deployment issue.