### PR TITLE
Fix(api): Correct routing order to resolve login error

### DIFF
--- a/game-backend-new/main.py
+++ b/game-backend-new/main.py
@@ -68,7 +68,6 @@ async def lifespan(app: FastAPI):
     yield
 
 app = FastAPI(lifespan=lifespan)
-app.mount("/", StaticFiles(directory="static", html=True), name="static")
 api_router = APIRouter()
 
 # Dependency to get DB session
@@ -310,3 +309,4 @@ async def bottle_wine(request: BottleWineRequest, db: Session = Depends(get_db),
     return bottled_wine
 
 app.include_router(api_router, prefix="/api")
+app.mount("/", StaticFiles(directory="static", html=True), name="static")


### PR DESCRIPTION
The login endpoint `/api/token` was returning a "405 Method Not Allowed" error because the FastAPI `StaticFiles` mount was incorrectly intercepting the request before it reached the API router. `StaticFiles` does not handle the `POST` method, leading to the error.

This was resolved by reordering the application setup in `main.py`. The API router is now included before the `StaticFiles` mount, ensuring that API routes are prioritized and correctly handled.